### PR TITLE
Handle scissor mode with high DPI screens.

### DIFF
--- a/rlImGui.cpp
+++ b/rlImGui.cpp
@@ -282,7 +282,20 @@ static void rlImGuiRenderTriangles(unsigned int count, int indexStart, const ImV
 static void EnableScissor(float x, float y, float width, float height)
 {
     rlEnableScissorTest();
-    rlScissor((int)x, GetScreenHeight() - (int)(y + height), (int)width, (int)height);
+#if defined(__APPLE__)
+    Vector2 scale = GetWindowScaleDPI();
+    rlScissor((int)(x*scale.x), (int)(GetScreenHeight()*scale.y - (((y + height)*scale.y))), (int)(width*scale.x), (int)(height*scale.y));
+#else
+    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
+    {
+        Vector2 scale = GetWindowScaleDPI();
+        rlScissor((int)(x*scale.x), (int)(CORE.Window.currentFbo.height - (y + height)*scale.y), (int)(width*scale.x), (int)(height*scale.y));
+    }
+    else
+    {
+        rlScissor((int)x, CORE.Window.currentFbo.height - (int)(y + height), (int)width, (int)height);
+    }
+#endif
 }
 
 static void rlRenderData(ImDrawData* data)


### PR DESCRIPTION
When running example program simple on a high DPI screen scissor, there is clipping of the ImGui::ShowDemoWindow window.

See screen shots taken:
1. MacBook Pro Intel retina display.
2. External Samsung display connected to MacBook Pro.

This fix is the same as one already done in Raylib Core (ref: [Fix scissor on macos #2170](https://github.com/raysan5/raylib/pull/2170))

This fix was tested on MacBook Pro Intel, macOS Monterey 12.3. I've cherry picked the fix to separate branch 'scissor' for this PR. My testing branch [add_cmake](https://github.com/lukekras/rlImGui/tree/add_cmake) has cmake added, so that I could build the project. If the project author desires cmake support, then I can submit another PR for cmake.

<img width="1281" alt="simple_high_DPI" src="https://user-images.githubusercontent.com/1853946/158760239-69a4b835-39b4-4249-9ab2-a910618fd39e.png">

![simple_non_high_DPI](https://user-images.githubusercontent.com/1853946/158760710-d8e49603-9996-4085-a931-733876e22e9b.png)

