### PR TITLE
Support for scaled framebuffer on high-dpi macOS screens

### DIFF
--- a/rlImGui.cpp
+++ b/rlImGui.cpp
@@ -33,6 +33,10 @@
 #include "raylib.h"
 #include "rlgl.h"
 
+#ifdef PLATFORM_DESKTOP
+#include <GLFW/glfw3.h>
+#endif
+
 #include <math.h>
 #include <vector>
 #include <map>
@@ -59,6 +63,16 @@ static void rlImGuiNewFrame()
 
     io.DisplaySize.x = float(GetScreenWidth());
     io.DisplaySize.y = float(GetScreenHeight());
+    int width = io.DisplaySize.x, height = io.DisplaySize.y;
+#ifdef PLATFORM_DESKTOP
+    glfwGetFramebufferSize(glfwGetCurrentContext(), &width, &height);
+#endif
+    if (width > 0 && height > 0) {
+        io.DisplayFramebufferScale = ImVec2((float)width / io.DisplaySize.x, (float)height / io.DisplaySize.y);
+    }
+    else {
+        io.DisplayFramebufferScale = ImVec2(1.0f, 1.0f);
+    }
 
     io.DeltaTime = GetFrameTime();
 
@@ -282,7 +296,8 @@ static void rlImGuiRenderTriangles(unsigned int count, int indexStart, const ImV
 static void EnableScissor(float x, float y, float width, float height)
 {
     rlEnableScissorTest();
-    rlScissor((int)x, GetScreenHeight() - (int)(y + height), (int)width, (int)height);
+    ImGuiIO& io = ImGui::GetIO();
+    rlScissor((int)x * io.DisplayFramebufferScale.x, (GetScreenHeight() - (int)(y + height)) * io.DisplayFramebufferScale.y, (int)width * io.DisplayFramebufferScale.x, (int)height * io.DisplayFramebufferScale.y);
 }
 
 static void rlRenderData(ImDrawData* data)


### PR DESCRIPTION
Adapt to glfw implicitly scaled frame buffers like on macOS with retina.