### PR TITLE
[CORE] Expose a function to get the actual frame buffer size regardless of DPI scale

### DIFF
--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -24,7 +24,7 @@ int main(int argc, char* argv[])
 	int screenWidth = 1280;
 	int screenHeight = 800;
 
-	SetConfigFlags(FLAG_MSAA_4X_HINT | FLAG_VSYNC_HINT);
+	SetConfigFlags(FLAG_MSAA_4X_HINT | FLAG_VSYNC_HINT | FLAG_WINDOW_RESIZABLE);
 	InitWindow(screenWidth, screenHeight, "raylib-Extras [ImGui] example - simple ImGui Demo");
 	SetTargetFPS(144);
 	rlImGuiSetup(true);


### PR DESCRIPTION
This PR adds a single function to raylib core. It exposes the raw GLFW frame buffer size.

This is needed for integrations with third party libs such as DearImGui. In order to have these libraries know the correct sizes for the frame buffer (and scissors), and to work aground some problems on MacOS.

I have been trying for about a year to find a way to get this to work on all platforms without adding a function to raylib, but there is just no consistent way to get the data.
I've been directly calling GLFW and that works for platforms that link raylib static, but any binding that uses raylib dynamic (like C#) can't do that, so I need a function that exposes this that is part of the export library.

This PR will make these external libs (mainly rlImGui) cleaner and easier to maintain.

If there is any other way to get this data, please let me know.