### PR TITLE
Update rlImGuiColors.h

### DIFF
--- a/rlImGuiColors.h
+++ b/rlImGuiColors.h
@@ -39,4 +39,9 @@ namespace rlImGuiColors
     {
         return ImVec4(color.r / 255.0f, color.g / 255.0f, color.b / 255.0f, color.a / 255.0f);
     }
+
+    inline ::Color Convert(ImVec4 color)
+    {
+        return ::Color{ (unsigned char)(color.x * 255.0f), (unsigned char)(color.y * 255.0f), (unsigned char)(color.z * 255.0f), (unsigned char)(color.w * 255.0f) };
+    }
 }


### PR DESCRIPTION
Override function to convert from ImVec4 back to Raylib Color R8G8B8A8 (32bit)