### PR TITLE
Update to allow linux compilation

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -81,6 +81,10 @@ workspace "rlImGui"
 		
 	filter { "platforms:x64" }
 		architecture "x86_64"
+
+	filter { "system:linux" }
+		defines { "_GLFW_X11" }
+		defines { "_GNU_SOURCE" }
 		
 	targetdir "bin/%{cfg.buildcfg}/"
 	


### PR DESCRIPTION
When I was trying to build this repo for Ubuntu 23.10 I was unable to do to an error.

Here are the following commands I ran to product this error.

```bash
dihydromonoxide@mycomputer:~/Projects/CppProjects/simple_dungeon/dependencies/rlImGui$ ./premake5 gmake
Using raylib dir raylib-master
Building configurations...
Running action 'gmake'...
Generated Makefile...
Generated _build/raylib.make...
Generated _build/rlImGui.make...
Generated _build/simple.make...
Generated _build/editor.make...
Generated _build/imgui_style_example.make...
Done (80ms).
dihydromonoxide@mycomputer:~/Projects/CppProjects/simple_dungeon/dependencies/rlImGui$ ls
_build    extras               imgui-master  Makefile  premake5.exe  premake5.osx       premake-VisualStudio.bat  raylib_premake5.lua  resources        rlImGui.cpp
examples  imgui_impl_raylib.h  LICENSE       premake5  premake5.lua  premake-mingw.bat  raylib-master             README.md            rlImGuiColors.h  rlImGui.h
dihydromonoxide@mycomputer:~/Projects/CppProjects/simple_dungeon/dependencies/rlImGui$ make
==== Building raylib (debug_x64) ====
Creating obj/x64/Debug/raylib
raudio.c
In file included from ../raylib-master/src/raudio.c:270:
../raylib-master/src/external/jar_xm.h:242: warning: "DEBUG" redefined
  242 | #define DEBUG(...)
      | 
<command-line>: note: this is the location of the previous definition
rcore.c
rglfw.c
../raylib-master/src/rglfw.c:57:10: error: #error "Cannot disable Wayland and X11 at the same time"
   57 |         #error "Cannot disable Wayland and X11 at the same time"
      |          ^~~~~
In file included from ../raylib-master/src/rglfw.c:99:
../raylib-master/src/external/glfw/src/posix_poll.c:27: warning: "_GNU_SOURCE" redefined
   27 | #define _GNU_SOURCE
      | 
<command-line>: note: this is the location of the previous definition
make[1]: *** [raylib.make:142: obj/x64/Debug/raylib/rglfw.o] Error 1
make: *** [Makefile:37: raylib] Error 2
```

To fix this error I added a option to the premake file on linux to tell it to use X11 and GNU sources. This was done according to this [issue](https://github.com/raysan5/raylib/issues/3882).