### PR TITLE
Remove unused variable in SetupFontAwesome

### DIFF
--- a/rlImGui.cpp
+++ b/rlImGui.cpp
@@ -262,7 +262,7 @@ void SetupFontAwesome(void)
 
     ImGuiIO& io = ImGui::GetIO();
 
-	auto* fontPtr = io.Fonts->AddFontFromMemoryCompressedTTF((void*)fa_solid_900_compressed_data, fa_solid_900_compressed_size, FONT_AWESOME_ICON_SIZE, &icons_config, icons_ranges);
+    io.Fonts->AddFontFromMemoryCompressedTTF((void*)fa_solid_900_compressed_data, fa_solid_900_compressed_size, FONT_AWESOME_ICON_SIZE, &icons_config, icons_ranges);
 #endif
 
 }


### PR DESCRIPTION
I'm getting a warning that this variable is unused. It does not look like this variable is referenced elsewhere, so I removed the name. 