### PR TITLE
Add tint color variants for all image functions

### DIFF
--- a/examples/editor.cpp
+++ b/examples/editor.cpp
@@ -95,6 +95,14 @@ public:
 				{
 					CurrentToolMode = ToolMode::Move;
 				}
+				ImGui::SameLine();
+
+				// temporarily reset window padding so that the
+				// color picker window doesn't look weird
+				ImVec2 windowPadding = ImGui::GetStyle().WindowPadding;
+				ImGui::PopStyleVar();
+				ImGui::ColorEdit3("Tint Color", TintColor, ImGuiColorEditFlags_NoInputs);
+				ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, windowPadding);
 
 				ImGui::SameLine();
 				switch (CurrentToolMode)
@@ -114,7 +122,8 @@ public:
 				ImGui::EndChild();
 			}
 
-			rlImGuiImageRect(&ViewTexture.texture, (int)size.x, (int)size.y, viewRect);	
+			Color tintCol = Color { (unsigned char)(TintColor[0] * 255), (unsigned char)(TintColor[1] * 255), (unsigned char)(TintColor[2] * 255), 255 };
+			rlImGuiImagePro(&ViewTexture.texture, size, viewRect, tintCol);	
 		}
 		ImGui::End();
 		ImGui::PopStyleVar();
@@ -182,6 +191,8 @@ public:
 	Vector2 LastMousePos = { 0 };
 	Vector2 LastTarget = { 0 };
 	bool Dragging = false;
+
+	float TintColor[3] = { 1.0f, 1.0f, 1.0f };
 
 	bool DirtyScene = false;
 

--- a/rlImGui.cpp
+++ b/rlImGui.cpp
@@ -492,98 +492,135 @@ void rlImGuiShutdown(void)
     GlobalContext = nullptr;
 }
 
-void rlImGuiImage(const Texture* image)
+static struct ImVec4 colorVec4(Color tintColor)
 {
-    if (!image)
-        return;
-    
-    if (GlobalContext)
-        ImGui::SetCurrentContext(GlobalContext);
-    
-    ImGui::Image((ImTextureID)image, ImVec2(float(image->width), float(image->height)));
+    return (ImVec4) {
+        (float)tintColor.r / 255.0f,
+        (float)tintColor.g / 255.0f,
+        (float)tintColor.b / 255.0f,
+        (float)tintColor.a / 255.0f,
+    };
 }
 
-bool rlImGuiImageButton(const char* name, const Texture* image)
+static void getTexCoords(const Texture* image, Rectangle sourceRect, struct ImVec2* uv0, struct ImVec2* uv1)
 {
-    if (!image)
-        return false;
-    
-    if (GlobalContext)
-        ImGui::SetCurrentContext(GlobalContext);
-    
-    return ImGui::ImageButton(name, (ImTextureID)image, ImVec2(float(image->width), float(image->height)));
-}
-
-bool rlImGuiImageButtonSize(const char* name, const Texture* image, ImVec2 size)
-{
-    if (!image)
-        return false;
-    
-    if (GlobalContext)
-        ImGui::SetCurrentContext(GlobalContext);
-   
-    return ImGui::ImageButton(name, (ImTextureID)image, size);
-}
-
-void rlImGuiImageSize(const Texture* image, int width, int height)
-{
-    if (!image)
-        return;
-    
-    if (GlobalContext)
-        ImGui::SetCurrentContext(GlobalContext);
-    
-    ImGui::Image((ImTextureID)image, ImVec2(float(width), float(height)));
-}
-
-void rlImGuiImageSizeV(const Texture* image, Vector2 size)
-{
-    if (!image)
-        return;
-    
-    if (GlobalContext)
-        ImGui::SetCurrentContext(GlobalContext);
-    
-    ImGui::Image((ImTextureID)image, ImVec2(size.x, size.y));
-}
-
-void rlImGuiImageRect(const Texture* image, int destWidth, int destHeight, Rectangle sourceRect)
-{
-    if (!image)
-        return;
-    
-    if (GlobalContext)
-        ImGui::SetCurrentContext(GlobalContext);
-    
-    ImVec2 uv0;
-    ImVec2 uv1;
-
     if (sourceRect.width < 0)
     {
-        uv0.x = -((float)sourceRect.x / image->width);
-        uv1.x = (uv0.x - (float)(fabs(sourceRect.width) / image->width));
+        uv0->x = -((float)sourceRect.x / image->width);
+        uv1->x = (uv0->x - (float)(fabs(sourceRect.width) / image->width));
     }
     else
     {
-        uv0.x = (float)sourceRect.x / image->width;
-        uv1.x = uv0.x + (float)(sourceRect.width / image->width);
+        uv0->x = (float)sourceRect.x / image->width;
+        uv1->x = uv0->x + (float)(sourceRect.width / image->width);
     }
 
     if (sourceRect.height < 0)
     {
-        uv0.y = -((float)sourceRect.y / image->height);
-        uv1.y = (uv0.y - (float)(fabs(sourceRect.height) / image->height));
+        uv0->y = -((float)sourceRect.y / image->height);
+        uv1->y = (uv0->y - (float)(fabs(sourceRect.height) / image->height));
     }
     else
     {
-        uv0.y = (float)sourceRect.y / image->height;
-        uv1.y = uv0.y + (float)(sourceRect.height / image->height);
+        uv0->y = (float)sourceRect.y / image->height;
+        uv1->y = uv0->y + (float)(sourceRect.height / image->height);
     }
-
-    ImGui::Image((ImTextureID)image, ImVec2(float(destWidth), float(destHeight)), uv0, uv1);
 }
 
-void rlImGuiImageRenderTexture(const RenderTexture* image)
+void rlImGuiImagePro(const Texture* image, struct ImVec2 size, Rectangle sourceRect, Color tintColor)
+{
+    if (!image)
+        return;
+    
+    if (GlobalContext)
+        ImGui::SetCurrentContext(GlobalContext);
+
+    struct ImVec2 uv0, uv1;
+    getTexCoords(image, sourceRect, &uv0, &uv1);
+    
+    ImGui::Image((ImTextureID)image, size, uv0, uv1, colorVec4(tintColor));
+}
+
+bool rlImGuiImageButtonPro(const char* name, const Texture* image, struct ImVec2 size, Rectangle sourceRect, Color tintColor)
+{
+    if (!image)
+        return false;
+    
+    if (GlobalContext)
+        ImGui::SetCurrentContext(GlobalContext);
+
+    struct ImVec2 uv0, uv1;
+    getTexCoords(image, sourceRect, &uv0, &uv1);
+   
+    return ImGui::ImageButton(name, (ImTextureID)image, size, uv0, uv1, colorVec4(tintColor));
+}
+
+void rlImGuiImageTint(const Texture* image, Color tintColor)
+{
+    Rectangle rec = (Rectangle) {0.0f, 0.0f, (float)image->width, (float)image->height};
+    return rlImGuiImagePro(image, ImVec2(float(image->width), float(image->height)), rec, tintColor);
+}
+
+void rlImGuiImage(const Texture* image)
+{
+    return rlImGuiImageTint(image, WHITE);
+}
+
+bool rlImGuiImageButtonTint(const char* name, const Texture* image, Color tintColor)
+{
+    Rectangle rec = (Rectangle) {0.0f, 0.0f, (float)image->width, (float)image->height };
+    return rlImGuiImageButtonPro(name, image, ImVec2(float(image->width), float(image->height)), rec, tintColor);
+}
+
+bool rlImGuiImageButton(const char* name, const Texture* image)
+{
+    return rlImGuiImageButtonTint(name, image, WHITE);
+}
+
+bool rlImGuiImageButtonSizeTint(const char* name, const Texture* image, struct ImVec2 size, Color tintColor)
+{
+    Rectangle rec = (Rectangle) {0.0f, 0.0f, (float)image->width, (float)image->height };
+    return rlImGuiImageButtonPro(name, image, size, rec, tintColor);
+}
+
+bool rlImGuiImageButtonSize(const char* name, const Texture* image, struct ImVec2 size)
+{
+    return rlImGuiImageButtonSizeTint(name, image, size, WHITE);
+}
+
+bool rlImGuiImageButtonRect(const char* name, const Texture* image, int destWidth, int destHeight, Rectangle sourceRect)
+{
+    return rlImGuiImageButtonPro(name, image, ImVec2(destWidth, destHeight), sourceRect, WHITE);
+}
+
+void rlImGuiImageSizeTintV(const Texture* image, struct ImVec2 size, Color tintColor)
+{
+    Rectangle rec = (Rectangle) {0.0f, 0.0f, (float)image->width, (float)image->height };
+    return rlImGuiImagePro(image, size, rec, tintColor);
+}
+
+void rlImGuiImageSizeTint(const Texture* image, int width, int height, Color tintColor)
+{
+    Rectangle rec = (Rectangle) {0.0f, 0.0f, (float)image->width, (float)image->height };
+    return rlImGuiImagePro(image, ImVec2((float)width, (float)height), rec, tintColor);
+}
+
+void rlImGuiImageSize(const Texture* image, int width, int height)
+{
+    return rlImGuiImageSizeTint(image, width, height, WHITE);
+}
+
+void rlImGuiImageSizeV(const Texture* image, struct ImVec2 size)
+{
+    return rlImGuiImageSizeTintV(image, size, WHITE);
+}
+
+void rlImGuiImageRect(const Texture* image, int destWidth, int destHeight, Rectangle sourceRect)
+{
+    return rlImGuiImagePro(image, ImVec2((float)destWidth, (float)destHeight), sourceRect, WHITE);
+}
+
+void rlImGuiImageRenderTextureTint(const RenderTexture* image, Color tintColor)
 {
     if (!image)
         return;
@@ -591,10 +628,15 @@ void rlImGuiImageRenderTexture(const RenderTexture* image)
     if (GlobalContext)
         ImGui::SetCurrentContext(GlobalContext);
     
-    rlImGuiImageRect(&image->texture, image->texture.width, image->texture.height, Rectangle{ 0,0, float(image->texture.width), -float(image->texture.height) });
+    rlImGuiImagePro(&image->texture, ImVec2((float)image->texture.width, (float)image->texture.height), Rectangle{ 0,0, float(image->texture.width), -float(image->texture.height) }, tintColor);
 }
 
-void rlImGuiImageRenderTextureFit(const RenderTexture* image, bool center)
+void rlImGuiImageRenderTexture(const RenderTexture* image)
+{
+    return rlImGuiImageRenderTextureTint(image, WHITE);
+}
+
+void rlImGuiImageRenderTextureFitTint(const RenderTexture* image, bool center, Color tintColor)
 {
     if (!image)
         return;
@@ -622,7 +664,12 @@ void rlImGuiImageRenderTextureFit(const RenderTexture* image, bool center)
         ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (area.y / 2 - sizeY / 2));
     }
 
-    rlImGuiImageRect(&image->texture, sizeX, sizeY, Rectangle{ 0,0, float(image->texture.width), -float(image->texture.height) });
+    rlImGuiImagePro(&image->texture, ImVec2((float)sizeX, (float)sizeY), Rectangle{ 0,0, float(image->texture.width), -float(image->texture.height) }, tintColor);
+}
+
+void rlImGuiImageRenderTextureFit(const RenderTexture* image, bool center)
+{
+    return rlImGuiImageRenderTextureFitTint(image, center, WHITE);
 }
 
 // raw ImGui backend API

--- a/rlImGui.h
+++ b/rlImGui.h
@@ -104,11 +104,72 @@ void rlImGuiBeginDelta(float deltaTime);
 // If you want to call ImGui image functions directly, simply pass them the pointer to the texture.
 
 /// <summary>
+/// Draw a portion texture as an image in an ImGui Context at a defined size and tint
+/// Uses the current ImGui Cursor position and the specified size
+/// The image will be scaled up or down to fit as needed
+/// </summary>
+/// <param name="image">The raylib texture to draw</param>
+/// <param name="destWidth">The width of the drawn image</param>
+/// <param name="destHeight">The height of the drawn image</param>
+/// <param name="sourceRect">The portion of the texture to draw as an image. Negative values for the width and height will flip the image</param>
+/// <param name="tintColor">The color to tint the image with</param>
+void rlImGuiImagePro(const Texture* image, struct ImVec2 size, Rectangle sourceRect, Color tintColor);
+
+/// <summary>
+/// Draw a portion texture as an image button in an ImGui Context at a defined size and tint
+/// Uses the current ImGui Cursor position and the specified size
+/// The image will be scaled up or down to fit as needed
+/// </summary>
+/// <param name="name">The display name and ImGui ID for the button</param>
+/// <param name="image">The texture to draw</param>
+/// <param name="size">The size of the drawn image</param>
+/// <param name="sourceRect">The portion of the texture to draw as an image. Negative values for the width and height will flip the image</param>
+/// <param name="tintColor">The color to tint the image with</param>
+bool rlImGuiImageButtonPro(const char* name, const Texture* image, struct ImVec2 size, Rectangle sourceRect, Color tintColor);
+
+/// <summary>
+/// Draw a texture as an image in an ImGui Context
+/// Uses the current ImGui Cursor position and the full texture size.
+/// </summary>
+/// <param name="image">The raylib texture to draw</param>
+/// <param name="tintColor">The color to tint the image with</param>
+void rlImGuiImageTint(const Texture *image, Color tintColor);
+
+/// <summary>
 /// Draw a texture as an image in an ImGui Context
 /// Uses the current ImGui Cursor position and the full texture size.
 /// </summary>
 /// <param name="image">The raylib texture to draw</param>
 void rlImGuiImage(const Texture *image);
+
+/// <summary>
+/// Draw a texture as an image in an ImGui Context at a specific size
+/// Uses the current ImGui Cursor position and the specified size
+/// The image will be scaled up or down to fit as needed
+/// </summary>
+/// <param name="image">The raylib texture to draw</param>
+/// <param name="size">The size of drawn image</param>
+/// <param name="tintColor">The 
+void rlImGuiImageSizeTintV(const Texture* image, struct ImVec2 size, Color tintColor);
+
+/// <summary>
+/// Draw a texture as an image in an ImGui Context at a specific size
+/// Uses the current ImGui Cursor position and the specified size
+/// The image will be scaled up or down to fit as needed
+/// </summary>
+/// <param name="image">The raylib texture to draw</param>
+/// <param name="size">The size of drawn image</param>
+void rlImGuiImageSizeV(const Texture* image, struct ImVec2 size);
+
+/// <summary>
+/// Draw a texture as an image in an ImGui Context at a specific size
+/// Uses the current ImGui Cursor position and the specified width and height
+/// The image will be scaled up or down to fit as needed
+/// </summary>
+/// <param name="image">The raylib texture to draw</param>
+/// <param name="width">The width of the drawn image</param>
+/// <param name="height">The height of the drawn image</param>
+void rlImGuiImageSizeTint(const Texture *image, int width, int height, Color tintColor);
 
 /// <summary>
 /// Draw a texture as an image in an ImGui Context at a specific size
@@ -119,15 +180,6 @@ void rlImGuiImage(const Texture *image);
 /// <param name="width">The width of the drawn image</param>
 /// <param name="height">The height of the drawn image</param>
 void rlImGuiImageSize(const Texture *image, int width, int height);
-
-/// <summary>
-/// Draw a texture as an image in an ImGui Context at a specific size
-/// Uses the current ImGui Cursor position and the specified size
-/// The image will be scaled up or down to fit as needed
-/// </summary>
-/// <param name="image">The raylib texture to draw</param>
-/// <param name="size">The size of drawn image</param>
-void rlImGuiImageSizeV(const Texture* image, Vector2 size);
 
 /// <summary>
 /// Draw a portion texture as an image in an ImGui Context at a defined size
@@ -144,7 +196,23 @@ void rlImGuiImageRect(const Texture* image, int destWidth, int destHeight, Recta
 /// Draws a render texture as an image an ImGui Context, automatically flipping the Y axis so it will show correctly on screen
 /// </summary>
 /// <param name="image">The render texture to draw</param>
+/// <param name="tintColor">The color to tint the image with</param>
+void rlImGuiImageRenderTextureTint(const RenderTexture* image, Color tintColor);
+
+/// <summary>
+/// Draws a render texture as an image an ImGui Context, automatically flipping the Y axis so it will show correctly on screen
+/// </summary>
+/// <param name="image">The render texture to draw</param>
 void rlImGuiImageRenderTexture(const RenderTexture* image);
+
+/// <summary>
+/// Draws a render texture as an image an ImGui Context, automatically flipping the Y axis so it will show correctly on screen
+/// Fits the render texture to the available content area
+/// </summary>
+/// <param name="image">The render texture to draw</param>
+/// <param name="center">When true the image will be centered in the content area</param>
+/// <param name="tintColor">The color to tint the image with</param>
+void rlImGuiImageRenderTextureFitTint(const RenderTexture* image, bool center, Color tintColor);
 
 /// <summary>
 /// Draws a render texture as an image an ImGui Context, automatically flipping the Y axis so it will show correctly on screen
@@ -160,7 +228,26 @@ void rlImGuiImageRenderTextureFit(const RenderTexture* image, bool center);
 /// <param name="name">The display name and ImGui ID for the button</param>
 /// <param name="image">The texture to draw</param>
 /// <returns>True if the button was clicked</returns>
+/// <param name="tintColor">The color to tint the image with</param>
+bool rlImGuiImageButtonTint(const char* name, const Texture* image, Color tintColor);
+
+/// <summary>
+/// Draws a texture as an image button in an ImGui context. Uses the current ImGui cursor position and the full size of the texture
+/// </summary>
+/// <param name="name">The display name and ImGui ID for the button</param>
+/// <param name="image">The texture to draw</param>
+/// <returns>True if the button was clicked</returns>
 bool rlImGuiImageButton(const char* name, const Texture* image);
+
+/// <summary>
+/// Draws a texture as an image button in an ImGui context. Uses the current ImGui cursor position and the specified size.
+/// </summary>
+/// <param name="name">The display name and ImGui ID for the button</param>
+/// <param name="image">The texture to draw</param>
+/// <param name="size">The size of the button</param>
+/// <param name="tintColor">The color to tint the image with</param>
+/// <returns>True if the button was clicked</returns>
+bool rlImGuiImageButtonSizeTint(const char* name, const Texture* image, struct ImVec2 size, Color tintColor);
 
 /// <summary>
 /// Draws a texture as an image button in an ImGui context. Uses the current ImGui cursor position and the specified size.
@@ -170,6 +257,19 @@ bool rlImGuiImageButton(const char* name, const Texture* image);
 /// <param name="size">The size of the button</param>
 /// <returns>True if the button was clicked</returns>
 bool rlImGuiImageButtonSize(const char* name, const Texture* image, struct ImVec2 size);
+
+/// <summary>
+/// Draw a portion texture as an image button in an ImGui Context at a defined size
+/// Uses the current ImGui Cursor position and the specified size
+/// The image will be scaled up or down to fit as needed
+/// </summary>
+/// <param name="name">The display name and ImGui ID for the button</param>
+/// <param name="image">The texture to draw</param>
+/// <param name="destWidth">The width of the drawn image</param>
+/// <param name="destHeight">The height of the drawn image</param>
+/// <param name="sourceRect">The portion of the texture to draw as an image. Negative values for the width and height will flip the image</param>
+/// <param name="tintColor">The color to tint the image with</param>
+bool rlImGuiImageButtonRect(const char* name, const Texture* image, int destWidth, int destHeight, Rectangle sourceRect);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is a port of the code I wrote for [the pull request for the C# version](https://github.com/raylib-extras/rlImGui-cs/pull/23) which, along with a C#-specific bug fix, adds tint color variants for all image functions.

However, there is a difference between the two versions. Since the C++ version cannot use operator overloading for the rlImGui functions (due to C externs), I created new functions with the suffix "Tint" added to them, as well as a function for image and image button drawing that has the suffix "Pro" that has position, source rect, and tint color parameters. I added the "Pro" functions because I also added a function for drawing ImageButtons with a defined source rectangle, as I did with the C# version.

But I'm not sure if I should port these new function names to C#, since I only did it because the C++ code could not use operator overloading. I would prefer keeping the C# names the same, since I find function overloading more convenient, but that would mean that the C++ and C# interfaces are different.