### PR TITLE
add API macro to export DLLs

### DIFF
--- a/rlImGui.cpp
+++ b/rlImGui.cpp
@@ -56,10 +56,10 @@ static bool LastShiftPressed = false;
 static bool LastAltPressed = false;
 static bool LastSuperPressed = false;
 
-bool rlImGuiIsControlDown() { return IsKeyDown(KEY_RIGHT_CONTROL) || IsKeyDown(KEY_LEFT_CONTROL); }
-bool rlImGuiIsShiftDown() { return IsKeyDown(KEY_RIGHT_SHIFT) || IsKeyDown(KEY_LEFT_SHIFT); }
-bool rlImGuiIsAltDown() { return IsKeyDown(KEY_RIGHT_ALT) || IsKeyDown(KEY_LEFT_ALT); }
-bool rlImGuiIsSuperDown() { return IsKeyDown(KEY_RIGHT_SUPER) || IsKeyDown(KEY_LEFT_SUPER); }
+RLIMGUIAPI bool rlImGuiIsControlDown() { return IsKeyDown(KEY_RIGHT_CONTROL) || IsKeyDown(KEY_LEFT_CONTROL); }
+RLIMGUIAPI bool rlImGuiIsShiftDown() { return IsKeyDown(KEY_RIGHT_SHIFT) || IsKeyDown(KEY_LEFT_SHIFT); }
+RLIMGUIAPI bool rlImGuiIsAltDown() { return IsKeyDown(KEY_RIGHT_ALT) || IsKeyDown(KEY_LEFT_ALT); }
+RLIMGUIAPI bool rlImGuiIsSuperDown() { return IsKeyDown(KEY_RIGHT_SUPER) || IsKeyDown(KEY_LEFT_SUPER); }
 
 void ReloadFonts(void)
 {
@@ -294,7 +294,7 @@ void SetupBackend(void)
     io.ClipboardUserData = nullptr;
 }
 
-void rlImGuiEndInitImGui(void)
+RLIMGUIAPI void rlImGuiEndInitImGui(void)
 {
     ImGui::SetCurrentContext(GlobalContext);
 
@@ -429,7 +429,7 @@ static void SetupGlobals(void)
     LastSuperPressed = false;
 }
 
-void rlImGuiBeginInitImGui(void)
+RLIMGUIAPI void rlImGuiBeginInitImGui(void)
 {
     SetupGlobals();
     if (GlobalContext == nullptr)
@@ -440,7 +440,7 @@ void rlImGuiBeginInitImGui(void)
     io.Fonts->AddFontDefault();
 }
 
-void rlImGuiSetup(bool dark)
+RLIMGUIAPI void rlImGuiSetup(bool dark)
 {
     rlImGuiBeginInitImGui();
 
@@ -452,20 +452,20 @@ void rlImGuiSetup(bool dark)
     rlImGuiEndInitImGui();
 }
 
-void rlImGuiReloadFonts(void)
+RLIMGUIAPI void rlImGuiReloadFonts(void)
 {
     ImGui::SetCurrentContext(GlobalContext);
 
     ReloadFonts();
 }
 
-void rlImGuiBegin(void)
+RLIMGUIAPI void rlImGuiBegin(void)
 {
     ImGui::SetCurrentContext(GlobalContext);
     rlImGuiBeginDelta(GetFrameTime());
 }
 
-void rlImGuiBeginDelta(float deltaTime)
+RLIMGUIAPI void rlImGuiBeginDelta(float deltaTime)
 {
     ImGui::SetCurrentContext(GlobalContext);
     ImGuiNewFrame(deltaTime);
@@ -473,14 +473,14 @@ void rlImGuiBeginDelta(float deltaTime)
     ImGui::NewFrame();
 }
 
-void rlImGuiEnd(void)
+RLIMGUIAPI void rlImGuiEnd(void)
 {
     ImGui::SetCurrentContext(GlobalContext);
     ImGui::Render();
     ImGui_ImplRaylib_RenderDrawData(ImGui::GetDrawData());
 }
 
-void rlImGuiShutdown(void)
+RLIMGUIAPI void rlImGuiShutdown(void)
 {
     if (GlobalContext == nullptr)
         return;
@@ -492,7 +492,7 @@ void rlImGuiShutdown(void)
     GlobalContext = nullptr;
 }
 
-void rlImGuiImage(const Texture* image)
+RLIMGUIAPI void rlImGuiImage(const Texture* image)
 {
     if (!image)
         return;
@@ -503,7 +503,7 @@ void rlImGuiImage(const Texture* image)
     ImGui::Image((ImTextureID)image, ImVec2(float(image->width), float(image->height)));
 }
 
-bool rlImGuiImageButton(const char* name, const Texture* image)
+RLIMGUIAPI bool rlImGuiImageButton(const char* name, const Texture* image)
 {
     if (!image)
         return false;
@@ -514,7 +514,7 @@ bool rlImGuiImageButton(const char* name, const Texture* image)
     return ImGui::ImageButton(name, (ImTextureID)image, ImVec2(float(image->width), float(image->height)));
 }
 
-bool rlImGuiImageButtonSize(const char* name, const Texture* image, ImVec2 size)
+RLIMGUIAPI bool rlImGuiImageButtonSize(const char* name, const Texture* image, ImVec2 size)
 {
     if (!image)
         return false;
@@ -525,7 +525,7 @@ bool rlImGuiImageButtonSize(const char* name, const Texture* image, ImVec2 size)
     return ImGui::ImageButton(name, (ImTextureID)image, size);
 }
 
-void rlImGuiImageSize(const Texture* image, int width, int height)
+RLIMGUIAPI void rlImGuiImageSize(const Texture* image, int width, int height)
 {
     if (!image)
         return;
@@ -536,7 +536,7 @@ void rlImGuiImageSize(const Texture* image, int width, int height)
     ImGui::Image((ImTextureID)image, ImVec2(float(width), float(height)));
 }
 
-void rlImGuiImageSizeV(const Texture* image, Vector2 size)
+RLIMGUIAPI void rlImGuiImageSizeV(const Texture* image, Vector2 size)
 {
     if (!image)
         return;
@@ -547,7 +547,7 @@ void rlImGuiImageSizeV(const Texture* image, Vector2 size)
     ImGui::Image((ImTextureID)image, ImVec2(size.x, size.y));
 }
 
-void rlImGuiImageRect(const Texture* image, int destWidth, int destHeight, Rectangle sourceRect)
+RLIMGUIAPI void rlImGuiImageRect(const Texture* image, int destWidth, int destHeight, Rectangle sourceRect)
 {
     if (!image)
         return;
@@ -583,7 +583,7 @@ void rlImGuiImageRect(const Texture* image, int destWidth, int destHeight, Recta
     ImGui::Image((ImTextureID)image, ImVec2(float(destWidth), float(destHeight)), uv0, uv1);
 }
 
-void rlImGuiImageRenderTexture(const RenderTexture* image)
+RLIMGUIAPI void rlImGuiImageRenderTexture(const RenderTexture* image)
 {
     if (!image)
         return;
@@ -594,7 +594,7 @@ void rlImGuiImageRenderTexture(const RenderTexture* image)
     rlImGuiImageRect(&image->texture, image->texture.width, image->texture.height, Rectangle{ 0,0, float(image->texture.width), -float(image->texture.height) });
 }
 
-void rlImGuiImageRenderTextureFit(const RenderTexture* image, bool center)
+RLIMGUIAPI void rlImGuiImageRenderTextureFit(const RenderTexture* image, bool center)
 {
     if (!image)
         return;

--- a/rlImGui.h
+++ b/rlImGui.h
@@ -32,6 +32,10 @@
 
 #include "raylib.h"
 
+#ifndef RLIMGUIAPI
+#define RLIMGUIAPI RLAPI
+#endif
+
 #ifndef NO_FONT_AWESOME
 #include "extras/IconsFontAwesome6.h"
 #define FONT_AWESOME_ICON_SIZE 11
@@ -50,25 +54,25 @@ extern "C" {
 /// Calls ImGui_ImplRaylib_Init and sets the theme. Will install Font awesome by default
 /// </summary>
 /// <param name="darkTheme">when true(default) the dark theme is used, when false the light theme is used</param>
-void rlImGuiSetup(bool darkTheme);
+RLIMGUIAPI void rlImGuiSetup(bool darkTheme);
 
 /// <summary>
 /// Starts a new ImGui Frame
 /// Calls ImGui_ImplRaylib_NewFrame, ImGui_ImplRaylib_ProcessEvents, and ImGui::NewFrame together
 /// </summary>
-void rlImGuiBegin(void);
+RLIMGUIAPI void rlImGuiBegin(void);
 
 /// <summary>
 /// Ends an ImGui frame and submits all ImGui drawing to raylib for processing.
 /// Calls ImGui:Render, an d ImGui_ImplRaylib_RenderDrawData to draw to the current raylib render target
 /// </summary>
-void rlImGuiEnd(void);
+RLIMGUIAPI void rlImGuiEnd(void);
 
 /// <summary>
 /// Cleanup ImGui and unload font atlas
 /// Calls ImGui_ImplRaylib_Shutdown
 /// </summary>
-void rlImGuiShutdown(void);
+RLIMGUIAPI void rlImGuiShutdown(void);
 
 // Advanced StartupAPI
 
@@ -77,19 +81,19 @@ void rlImGuiShutdown(void);
 /// must be followed by rlImGuiEndInitImGui
 /// Called by ImGui_ImplRaylib_Init, and does the first part of setup, before fonts are rendered
 /// </summary>
-void rlImGuiBeginInitImGui(void);
+RLIMGUIAPI void rlImGuiBeginInitImGui(void);
 
 /// <summary>
 /// End Custom initialization. Not needed if you call rlImGuiSetup. Only needed if you want to add custom setup code.
 /// must be proceeded by rlImGuiBeginInitImGui
 /// Called by ImGui_ImplRaylib_Init and does the second part of setup, and renders fonts.
 /// </summary>
-void rlImGuiEndInitImGui(void);
+RLIMGUIAPI void rlImGuiEndInitImGui(void);
 
 /// <summary>
 /// Forces the font texture atlas to be recomputed and re-cached
 /// </summary>
-void rlImGuiReloadFonts(void);
+RLIMGUIAPI void rlImGuiReloadFonts(void);
 
 // Advanced Update API
 
@@ -97,7 +101,7 @@ void rlImGuiReloadFonts(void);
 /// Starts a new ImGui Frame with a specified delta time
 /// </summary>
 /// <param name="dt">delta time, any value < 0 will use raylib GetFrameTime</param>
-void rlImGuiBeginDelta(float deltaTime);
+RLIMGUIAPI void rlImGuiBeginDelta(float deltaTime);
 
 // ImGui Image API extensions
 // Purely for convenience in working with raylib textures as images.
@@ -108,7 +112,7 @@ void rlImGuiBeginDelta(float deltaTime);
 /// Uses the current ImGui Cursor position and the full texture size.
 /// </summary>
 /// <param name="image">The raylib texture to draw</param>
-void rlImGuiImage(const Texture *image);
+RLIMGUIAPI void rlImGuiImage(const Texture *image);
 
 /// <summary>
 /// Draw a texture as an image in an ImGui Context at a specific size
@@ -118,7 +122,7 @@ void rlImGuiImage(const Texture *image);
 /// <param name="image">The raylib texture to draw</param>
 /// <param name="width">The width of the drawn image</param>
 /// <param name="height">The height of the drawn image</param>
-void rlImGuiImageSize(const Texture *image, int width, int height);
+RLIMGUIAPI void rlImGuiImageSize(const Texture *image, int width, int height);
 
 /// <summary>
 /// Draw a texture as an image in an ImGui Context at a specific size
@@ -127,7 +131,7 @@ void rlImGuiImageSize(const Texture *image, int width, int height);
 /// </summary>
 /// <param name="image">The raylib texture to draw</param>
 /// <param name="size">The size of drawn image</param>
-void rlImGuiImageSizeV(const Texture* image, Vector2 size);
+RLIMGUIAPI void rlImGuiImageSizeV(const Texture* image, Vector2 size);
 
 /// <summary>
 /// Draw a portion texture as an image in an ImGui Context at a defined size
@@ -138,13 +142,13 @@ void rlImGuiImageSizeV(const Texture* image, Vector2 size);
 /// <param name="destWidth">The width of the drawn image</param>
 /// <param name="destHeight">The height of the drawn image</param>
 /// <param name="sourceRect">The portion of the texture to draw as an image. Negative values for the width and height will flip the image</param>
-void rlImGuiImageRect(const Texture* image, int destWidth, int destHeight, Rectangle sourceRect);
+RLIMGUIAPI void rlImGuiImageRect(const Texture* image, int destWidth, int destHeight, Rectangle sourceRect);
 
 /// <summary>
 /// Draws a render texture as an image an ImGui Context, automatically flipping the Y axis so it will show correctly on screen
 /// </summary>
 /// <param name="image">The render texture to draw</param>
-void rlImGuiImageRenderTexture(const RenderTexture* image);
+RLIMGUIAPI void rlImGuiImageRenderTexture(const RenderTexture* image);
 
 /// <summary>
 /// Draws a render texture as an image an ImGui Context, automatically flipping the Y axis so it will show correctly on screen
@@ -152,7 +156,7 @@ void rlImGuiImageRenderTexture(const RenderTexture* image);
 /// </summary>
 /// <param name="image">The render texture to draw</param>
 /// <param name="center">When true the image will be centered in the content area</param>
-void rlImGuiImageRenderTextureFit(const RenderTexture* image, bool center);
+RLIMGUIAPI void rlImGuiImageRenderTextureFit(const RenderTexture* image, bool center);
 
 /// <summary>
 /// Draws a texture as an image button in an ImGui context. Uses the current ImGui cursor position and the full size of the texture
@@ -160,7 +164,7 @@ void rlImGuiImageRenderTextureFit(const RenderTexture* image, bool center);
 /// <param name="name">The display name and ImGui ID for the button</param>
 /// <param name="image">The texture to draw</param>
 /// <returns>True if the button was clicked</returns>
-bool rlImGuiImageButton(const char* name, const Texture* image);
+RLIMGUIAPI bool rlImGuiImageButton(const char* name, const Texture* image);
 
 /// <summary>
 /// Draws a texture as an image button in an ImGui context. Uses the current ImGui cursor position and the specified size.
@@ -169,7 +173,7 @@ bool rlImGuiImageButton(const char* name, const Texture* image);
 /// <param name="image">The texture to draw</param>
 /// <param name="size">The size of the button</param>
 /// <returns>True if the button was clicked</returns>
-bool rlImGuiImageButtonSize(const char* name, const Texture* image, struct ImVec2 size);
+RLIMGUIAPI bool rlImGuiImageButtonSize(const char* name, const Texture* image, struct ImVec2 size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When compiling Raylib and Imgui as a DLL it would make sense to also import/export the the functions of rlImGui appropriately. 

For that I added a macro `RLIMGUIAPI` that can be overriden by the user. Otherwise it will be the same as `RLAPI`.