### PR TITLE
Fixed asset browser and editor examples

### DIFF
--- a/examples/asset_browser/asset_browser.cpp
+++ b/examples/asset_browser/asset_browser.cpp
@@ -18,6 +18,19 @@
 #include "raylib.h"
 #include "extras/IconsFontAwesome6.h"
 
+#ifdef __APPLE__
+#include <ctype.h>
+#include <string.h>
+
+int stricmp(const char *s1, const char *s2) {
+    while (*s1 && (tolower((unsigned char)*s1) == tolower((unsigned char)*s2))) {
+        s1++;
+        s2++;
+    }
+    return tolower((unsigned char)*s1) - tolower((unsigned char)*s2);
+}
+#endif
+
 
 AssetBrowserPanel::AssetBrowserPanel()
 {

--- a/examples/editor.cpp
+++ b/examples/editor.cpp
@@ -67,7 +67,15 @@ public:
 		if (ImGui::Begin("Image Viewer", &Open, ImGuiWindowFlags_NoScrollbar))
 		{
 			// save off the screen space content rectangle
-			ContentRect = { ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMin().x, ImGui::GetWindowPos().y + ImGui::GetWindowContentRegionMin().y, ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y };
+			ImVec2 cursorScreenPos = ImGui::GetCursorScreenPos();
+			ImVec2 contentRegionAvail = ImGui::GetContentRegionAvail();
+
+			ContentRect = { 
+				cursorScreenPos.x,  // This replaces windowPos.x + GetWindowContentRegionMin().x
+				cursorScreenPos.y,  // This replaces windowPos.y + GetWindowContentRegionMin().y
+				contentRegionAvail.x,
+				contentRegionAvail.y
+			};
 
 			Focused = ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows);
 


### PR DESCRIPTION
Examples failed to compile on latest dear imgui 1.9.1

Firstly the removal of GetWindowContentRegionMin (see https://github.com/ocornut/imgui/issues/7838)

Secondly, on osx there is no stricmp, so I have created a helper function for this.

With this patch, rlImGui + examples compile perfectly on macos (arm64)

```
chmod +x ./premake5.osx
./premake5.osx --os=macosx gmake2
make

==== Building raylib (debug_x64) ====
==== Building rlImGui (debug_x64) ====
==== Building simple (debug_x64) ====
==== Building editor (debug_x64) ====
==== Building imgui_style_example (debug_x64) ====
==== Building docking_example (debug_x64) ====
==== Building asset_browser (debug_x64) ====
```

Whilst the build log says debug_x64, the outputted files on my machine are

```
Mach-O 64-bit executable arm64
```
