### PR TITLE
Change from "ImGuiIO. [Get/Set]ClipboardTextFn" to "ImGuiPlatformIO.Platform_[Get/Set]ClipboardTextFn"

### DIFF
--- a/rlImGui.cpp
+++ b/rlImGui.cpp
@@ -37,7 +37,6 @@
 #include <math.h>
 #include <map>
 #include <limits>
-#include <cstdint>
 
 #ifndef NO_FONT_AWESOME
 #include "extras/FA6FreeSolidFontData.h"
@@ -87,7 +86,7 @@ void ReloadFonts(void)
     io.Fonts->TexID = fontTexture;
 }
 
-static const char* GetClipTextCallback(ImGuiContext*)
+static const char* GetClipTextCallback(ImGuiContext*) 
 {
     return GetClipboardText();
 }
@@ -290,8 +289,7 @@ void SetupBackend(void)
 
     io.MousePos = ImVec2(0, 0);
 
-    ImGuiPlatformIO& platformIO = ImGui::GetPlatformIO();
-
+    ImGuiPlatformIO platformIO = ImGui::GetPlatformIO();
     platformIO.Platform_SetClipboardTextFn = SetClipTextCallback;
     platformIO.Platform_GetClipboardTextFn = GetClipTextCallback;
 

--- a/rlImGui.cpp
+++ b/rlImGui.cpp
@@ -289,7 +289,7 @@ void SetupBackend(void)
 
     io.MousePos = ImVec2(0, 0);
 
-    ImGuiPlatformIO platformIO = ImGui::GetPlatformIO();
+    ImGuiPlatformIO& platformIO = ImGui::GetPlatformIO();
     platformIO.Platform_SetClipboardTextFn = SetClipTextCallback;
     platformIO.Platform_GetClipboardTextFn = GetClipTextCallback;
 

--- a/rlImGui.h
+++ b/rlImGui.h
@@ -56,9 +56,7 @@
 
 #ifndef NO_FONT_AWESOME
 #include "extras/IconsFontAwesome6.h"
-#ifndef FONT_AWESOME_ICON_SIZE
 #define FONT_AWESOME_ICON_SIZE 11
-#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
In the new [Dear ImGui release](https://github.com/ocornut/imgui/releases/tag/v1.91.1), some IO handlers were changed from ImGuiIO to ImGuiPlatformIO.

Pull request changes: Replaces usage of the legacy API for the new one.