### PR TITLE
Fix typo in ImGui_ImplRaylib_BuildFontAtlas

### DIFF
--- a/examples/imgui_style_example.cpp
+++ b/examples/imgui_style_example.cpp
@@ -48,7 +48,7 @@ int main(int, char**)
     IM_ASSERT(font != nullptr);
 
     // required to be called to cache the font texture with raylib
-    Imgui_ImplRaylib_BuildFontAtlas();
+    ImGui_ImplRaylib_BuildFontAtlas();
    
     // Our state
     bool show_demo_window = true;

--- a/imgui_impl_raylib.h
+++ b/imgui_impl_raylib.h
@@ -45,7 +45,7 @@
 #ifndef IMGUI_DISABLE
 
 IMGUI_IMPL_API bool ImGui_ImplRaylib_Init(void);
-IMGUI_IMPL_API void Imgui_ImplRaylib_BuildFontAtlas(void);
+IMGUI_IMPL_API void ImGui_ImplRaylib_BuildFontAtlas(void);
 IMGUI_IMPL_API void ImGui_ImplRaylib_Shutdown(void);
 IMGUI_IMPL_API void ImGui_ImplRaylib_NewFrame(void);
 IMGUI_IMPL_API void ImGui_ImplRaylib_RenderDrawData(ImDrawData* draw_data);

--- a/rlImGui.cpp
+++ b/rlImGui.cpp
@@ -643,7 +643,7 @@ bool ImGui_ImplRaylib_Init(void)
     return true;
 }
 
-void Imgui_ImplRaylib_BuildFontAtlas(void)
+void ImGui_ImplRaylib_BuildFontAtlas(void)
 {
     ReloadFonts();
 }


### PR DESCRIPTION
Uppercase the 'g'. This lines up with the other function names.