### PR TITLE
Swapped struct ImVec2 in header for Vector2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ void rlImGuiImageRenderTexture(const RenderTexture* image);
 void rlImGuiImageRenderTextureFit(const RenderTexture* image, bool center);
 
 bool rlImGuiImageButton(const Texture *image);
-bool rlImGuiImageButtonSize(const char* name, const Texture* image, struct ImVec2 size);
+bool rlImGuiImageButtonSize(const char* name, const Texture* image, Vector2 size);
 ```
 
 # C vs C++

--- a/rlImGui.cpp
+++ b/rlImGui.cpp
@@ -495,7 +495,7 @@ bool rlImGuiImageButton(const char* name, const Texture* image)
     return ImGui::ImageButton(name, (ImTextureID)image, ImVec2(float(image->width), float(image->height)));
 }
 
-bool rlImGuiImageButtonSize(const char* name, const Texture* image, ImVec2 size)
+bool rlImGuiImageButtonSize(const char* name, const Texture* image, Vector2 size)
 {
     if (!image)
         return false;
@@ -503,7 +503,7 @@ bool rlImGuiImageButtonSize(const char* name, const Texture* image, ImVec2 size)
     if (GlobalContext)
         ImGui::SetCurrentContext(GlobalContext);
    
-    return ImGui::ImageButton(name, (ImTextureID)image, size);
+    return ImGui::ImageButton(name, (ImTextureID)image, ImVec2(size.x, size.y));
 }
 
 void rlImGuiImageSize(const Texture* image, int width, int height)

--- a/rlImGui.h
+++ b/rlImGui.h
@@ -193,7 +193,7 @@ bool rlImGuiImageButton(const char* name, const Texture* image);
 /// <param name="image">The texture to draw</param>
 /// <param name="size">The size of the button</param>
 /// <returns>True if the button was clicked</returns>
-RLIMGUIAPI bool rlImGuiImageButtonSize(const char* name, const Texture* image, struct ImVec2 size);
+RLIMGUIAPI bool rlImGuiImageButtonSize(const char* name, const Texture* image, Vector2 size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The `rlImGuiImageButtonSize()` function's `size` parameter is a `struct ImVec2`, when all other functions use Raylib types instead of ImGui types for parameters. This function causes a compilation issue if you don't have `imgui.h` included before using `rlImGui.h`.

This PR swaps the parameter type to the Raylib type `Vector2`.