### PR TITLE
Implicit casting issues

### DIFF
--- a/rlImGui.cpp
+++ b/rlImGui.cpp
@@ -212,7 +212,7 @@ static void ImGuiRenderTriangles(unsigned int count, int indexStart, const ImVec
     if (count < 3)
         return;
 
-    unsigned int textureId = unsigned int (texturePtr);
+    unsigned int textureId = (unsigned int)(texturePtr);
 
     rlBegin(RL_TRIANGLES);
     rlSetTexture(textureId);


### PR DESCRIPTION
Tried to compile rlImGui to a project I made but got this error with _gcc 14.2.1_ using _CMake 3.31.6_ (tested CXX Standard 11 and 20).

I tried to cast in C-style like the rest of the project, however I would suggest using a more proper C++ type-safe casting such as:
```cpp
static_cast<foo>(bar);
dynamic_cast<foo>(bar);
reinterpret_cast<foo>(bar);
```
For the rest of the project ? Such implicit casting can lead to unexpected behaviors: C compilers do whatever they want... (Source: [here](https://en.cppreference.com/w/cpp/language/explicit_cast)).

I know that a lot of this project is C-like, however because we are using Dear ImGui C++ bindings, why not use proper syntax from _C++11_ ☺️ ?
I'll be happy to help!
