### PR TITLE
Minor typo fixes for Building section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Raylib integration with DearImGui
 rlImgui provides a backend for [Dear ImGui](https://github.com/ocornut/imgui) using [Raylib](https://www.raylib.com/). 
 
 # Building
-the rlImGui repository itself is setup to use premake to generate a static library and examples for Visual Studio 2019. Premake can also be used to generate makefiles for linux. rlImGui can be used as a static library, or by directly including the files into your game project.
+The rlImGui repository itself is set up to use Premake to generate a static library and examples for Visual Studio 2019. Premake can also be used to generate makefiles for Linux. rlImGui can be used as a static library, or by directly including the files into your game project.
 Premake is not required to use rlImGui, it is simply just what is used for development.
 
 ## Other Systems

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Raylib integration with DearImGui
 rlImgui provides a backend for [Dear ImGui](https://github.com/ocornut/imgui) using [Raylib](https://www.raylib.com/). 
 
 # Building
-the rlImGui repository itself is setup to use premake to generate a static library and examples for Visual Studio 2019. Premake can also be used to generate makefiles for linux. rlImGui can be used as a static library, or by direclty including the files into your game project.
+the rlImGui repository itself is setup to use premake to generate a static library and examples for Visual Studio 2019. Premake can also be used to generate makefiles for linux. rlImGui can be used as a static library, or by directly including the files into your game project.
 Premake is not required to use rlImGui, it is simply just what is used for development.
 
 ## Other Systems

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ rlImgui provides a backend for [Dear ImGui](https://github.com/ocornut/imgui) us
 
 # Building
 the rlImGui repository itself is setup to use premake to generate a static library and examples for Visual Studio 2019. Premake can also be used to generate makefiles for linux. rlImGui can be used as a static library, or by direclty including the files into your game project.
-Preamke is not required to use rlImGui, it is simply just what is used for development.
+Premake is not required to use rlImGui, it is simply just what is used for development.
 
 ## Other Systems
 rlImGui has no dependencies other than raylib and imgui. If you want to use any other build system, you can simply just build rlImGui and ImGui into a library, or even add the files direclty to your game if it can use C++ code. There are no specific build requirements for rlImgui itself.


### PR DESCRIPTION
This fixes a few minor typos I noticed in the "Building" section of the README:

- Preamke -> Premake
- direclty -> directly
- the -> The (capitalization for beginning of a sentence)
- premake -> Premake (capitalization of proper noun; aligns with [Premake docs](https://premake.github.io/docs/What-Is-Premake))
- linux -> Linux (capitalization of proper noun; aligns with [Wikipedia](https://en.wikipedia.org/wiki/Linux))
- setup -> set up (setup is a noun, set up is a verb)