### PR TITLE
Replace undefined Vector2Ones in Emscripten version of GetDisplayScale

### DIFF
--- a/rlImGui.cpp
+++ b/rlImGui.cpp
@@ -94,7 +94,7 @@ void ImGui_ImplRaylib_FreeBackendData()
 Vector2 GetDisplayScale()
 {
 #if defined(__EMSCRIPTEN__)
-    return Vector2Ones;
+    return Vector2{1, 1};
 #else
     return GetWindowScaleDPI();
 #endif


### PR DESCRIPTION
`GetDisplayScale` currently returns `Vector2Ones` in the Emscripten build, but `Vector2Ones` isn't defined anywhere.