### PR TITLE
Reset texture after each draw in draw list rather than once at the end

### DIFF
--- a/rlImGui.cpp
+++ b/rlImGui.cpp
@@ -223,6 +223,7 @@ static void ImGuiRenderTriangles(unsigned int count, int indexStart, const ImVec
         ImGuiTriangleVert(vertexC);
     }
     rlEnd();
+	rlSetTexture(0);
 }
 
 static void EnableScissor(float x, float y, float width, float height)
@@ -785,7 +786,6 @@ void ImGui_ImplRaylib_RenderDrawData(ImDrawData* draw_data)
         }
     }
 
-    rlSetTexture(0);
     rlDisableScissorTest();
     rlEnableBackfaceCulling();
 }


### PR DESCRIPTION
This change allows the user callback code in the draw list to call raylib draw function. Certain raylib draw functions does not set a texture through `rlSetTexture(GetShapesTexture().id);` (such as DrawLine) which results in them being invisible when rlSetTexture is set to an unknown ImGui texture. Maybe the currently set texture is the window background texture from ImGui?

For example, this below code:

```cpp
#include "raylib.h"
#include "rlImGui.h"
#include "imgui.h"

auto main() -> int {
    InitWindow(1200, 600, "Raylib bug???");
    SetTargetFPS(60);

    rlImGuiSetup(true);

    while (!WindowShouldClose()) {
        BeginDrawing();
        ClearBackground(BLACK);

        rlImGuiBegin();

        if (ImGui::Begin("Test")) {
            ImGui::GetWindowDrawList()->AddCallback([](auto, auto) -> void {
                DrawLine(200, 300, 1000, 300, WHITE);
            });
        }
        ImGui::End();

        rlImGuiEnd();

        EndDrawing();
    }

    rlImGuiShutdown();

    CloseWindow();
}
```

Does not render the line shown in the below image.

<img width="1200" height="600" alt="unpatched" src="https://github.com/user-attachments/assets/019ba9ac-1c2a-420c-8504-7e4ceb35cbfc" />

After applying the patch, the line is drawn properly.

<img width="1200" height="600" alt="patched" src="https://github.com/user-attachments/assets/93f1ebc6-e603-4930-9f3c-e0b94df6b991" />

Althrough it might be a better idea to use a RenderTexture, this fix might simplify the user code (like mine!).