### PR TITLE
build static libs on github CI for available target triples

### DIFF
--- a/.github/workflows/build-libs.yml
+++ b/.github/workflows/build-libs.yml
@@ -1,0 +1,160 @@
+name: Build static libraries
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to attach libraries to (empty = libs-<commit>)
+        required: false
+        default: ''
+      raylib_ref:
+        description: raylib git ref to build against (keep in sync with odin-raylib)
+        required: false
+        default: '6.0'
+      imgui_ref:
+        description: imgui git ref to build against (docking branch, keep in sync with ui-mvp bindings)
+        required: false
+        default: 'v1.92.8-docking'
+      dear_bindings_ref:
+        description: dear_bindings git ref used to generate the imgui C API
+        required: false
+        default: 'DearBindings_v0.21_ImGui_v1.92.8-docking'
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: rlImGui-libs-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      raylib_ref: ${{ steps.meta.outputs.raylib_ref }}
+      imgui_ref: ${{ steps.meta.outputs.imgui_ref }}
+      dear_bindings_ref: ${{ steps.meta.outputs.dear_bindings_ref }}
+    steps:
+      - name: Resolve tag and versions
+        id: meta
+        shell: bash
+        run: |
+          {
+            echo "raylib_ref=${{ inputs.raylib_ref || '6.0' }}"
+            echo "imgui_ref=${{ inputs.imgui_ref || 'v1.92.8-docking' }}"
+            echo "dear_bindings_ref=${{ inputs.dear_bindings_ref || 'DearBindings_v0.21_ImGui_v1.92.8-docking' }}"
+            if [[ "${{ github.event_name }}" == "push" ]]; then
+              echo "tag=${GITHUB_REF#refs/tags/}"
+            elif [[ -n "${{ inputs.tag }}" ]]; then
+              echo "tag=${{ inputs.tag }}"
+            else
+              echo "tag=libs-${GITHUB_SHA::8}"
+            fi
+          } >> "$GITHUB_OUTPUT"
+      - name: Create release if missing
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json tagName >/dev/null 2>&1; then
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --generate-notes --title "$TAG"
+          fi
+
+  build:
+    name: Build ${{ matrix.triple }}
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - triple: x86_64-apple-darwin
+            os: macos-15-intel
+          - triple: aarch64-apple-darwin
+            os: macos-14
+          - triple: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - triple: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+          - triple: x86_64-pc-windows-msvc
+            os: windows-latest
+          - triple: wasm32-unknown-emscripten
+            os: ubuntu-latest
+            emsdk: true
+    runs-on: ${{ matrix.os }}
+    env:
+      TRIPLE: ${{ matrix.triple }}
+      RAYLIB_REF: ${{ needs.prepare.outputs.raylib_ref }}
+      IMGUI_REF: ${{ needs.prepare.outputs.imgui_ref }}
+      DEAR_BINDINGS_REF: ${{ needs.prepare.outputs.dear_bindings_ref }}
+      RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Clone raylib ${{ env.RAYLIB_REF }}
+        shell: bash
+        run: git clone --depth 1 --branch "$RAYLIB_REF" https://github.com/raysan5/raylib.git raylib
+      - name: Clone imgui ${{ env.IMGUI_REF }}
+        shell: bash
+        run: git clone --depth 1 --branch "$IMGUI_REF" https://github.com/ocornut/imgui.git imgui
+      - name: Clone dear_bindings ${{ env.DEAR_BINDINGS_REF }}
+        shell: bash
+        run: git clone --depth 1 --branch "$DEAR_BINDINGS_REF" https://github.com/dearimgui/dear_bindings.git dear_bindings
+      - name: Generate imgui C API
+        shell: bash
+        run: |
+          PY=$(command -v python3 || command -v python)
+          "$PY" -m pip install --quiet ply
+          mkdir -p generated
+          "$PY" dear_bindings/dear_bindings.py --nogeneratedefaultargfunctions -o generated/dcimgui imgui/imgui.h
+      - name: Set up Emscripten
+        if: matrix.emsdk
+        uses: myMindstorm/setup-emsdk@v14
+      - name: Build library
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash scripts/build-lib.sh "$TRIPLE" dist
+      - name: Build library (MSVC)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: scripts\build-lib-msvc.bat dist
+      - name: Upload assets to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$RELEASE_TAG" dist/* --clobber
+
+  package:
+    name: Package all libraries into a zip
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+    steps:
+      - name: Download library assets from release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p libs
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern 'librlImGui-*' --pattern 'rlImGui-*.lib' --dir libs
+      - name: Create zip of all libraries
+        shell: bash
+        run: |
+          cd libs
+          zip -q "../rlImGui-libs-$RELEASE_TAG.zip" ./*
+      - name: Upload zip to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$RELEASE_TAG" "rlImGui-libs-$RELEASE_TAG.zip" --repo "$GITHUB_REPOSITORY" --clobber

--- a/scripts/build-lib-msvc.bat
+++ b/scripts/build-lib-msvc.bat
@@ -1,0 +1,58 @@
+@echo off
+rem Builds rlImGui as an MSVC static library for Windows x64 (rlImGui-x86_64-pc-windows-msvc.lib).
+rem Locates the newest Visual Studio install and calls vcvars64.bat itself, so it must run on
+rem Windows with the "Desktop development with C++" workload installed (e.g. windows-latest).
+rem
+rem Usage: build-lib-msvc.bat [out-dir]
+
+setlocal
+
+set "OUT_DIR=%~1"
+if "%OUT_DIR%"=="" set "OUT_DIR=%CD%"
+
+set "RAYLIB_DIR=raylib"
+set "IMGUI_DIR=imgui"
+set "GENERATED_DIR=generated"
+
+if not exist "%RAYLIB_DIR%" (
+	echo error: missing dependency directory '%RAYLIB_DIR%' 1>&2
+	exit /b 1
+)
+if not exist "%IMGUI_DIR%" (
+	echo error: missing dependency directory '%IMGUI_DIR%' 1>&2
+	exit /b 1
+)
+if not exist "%GENERATED_DIR%\dcimgui.cpp" (
+	echo error: missing generated C API '%GENERATED_DIR%\dcimgui.cpp' ^(run dear_bindings first^) 1>&2
+	exit /b 1
+)
+
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" (
+	echo error: Visual Studio Installer ^(vswhere.exe^) not found 1>&2
+	exit /b 1
+)
+for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSROOT=%%i"
+if not defined VSROOT (
+	echo error: no Visual Studio installation with the C++ workload found 1>&2
+	exit /b 1
+)
+call "%VSROOT%\VC\Auxiliary\Build\vcvars64.bat" >nul
+if errorlevel 1 exit /b 1
+
+set "BUILD_DIR=%OUT_DIR%\.build-msvc"
+if exist "%BUILD_DIR%" rmdir /s /q "%BUILD_DIR%"
+mkdir "%BUILD_DIR%"
+
+for %%s in (rlImGui.cpp "%IMGUI_DIR%\imgui.cpp" "%IMGUI_DIR%\imgui_demo.cpp" "%IMGUI_DIR%\imgui_draw.cpp" "%IMGUI_DIR%\imgui_tables.cpp" "%IMGUI_DIR%\imgui_widgets.cpp" "%GENERATED_DIR%\dcimgui.cpp") do (
+	cl -nologo -O2 -std:c++17 -EHsc -DNDEBUG -DPLATFORM_DESKTOP -DGRAPHICS_API_OPENGL_33 -DIMGUI_DISABLE_OBSOLETE_FUNCTIONS -DIMGUI_DISABLE_OBSOLETE_KEYIO -D_WINSOCK_DEPRECATED_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -I. -I"%IMGUI_DIR%" -I"%GENERATED_DIR%" -I"%RAYLIB_DIR%\src" -I"%RAYLIB_DIR%\src\external" -I"%RAYLIB_DIR%\src\external\glfw\include" -c "%%s" -Fo"%BUILD_DIR%\\"
+	if errorlevel 1 exit /b 1
+)
+
+lib -nologo -out:"%OUT_DIR%\rlImGui-x86_64-pc-windows-msvc.lib" "%BUILD_DIR%\*.obj"
+if errorlevel 1 exit /b 1
+
+rmdir /s /q "%BUILD_DIR%"
+
+echo built %OUT_DIR%\rlImGui-x86_64-pc-windows-msvc.lib
+exit /b 0

--- a/scripts/build-lib.sh
+++ b/scripts/build-lib.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Builds rlImGui as a static library for a single target triple.
+# Only raylib headers are required, raylib itself is not built or linked.
+#
+# Usage:
+#   scripts/build-lib.sh <target-triple> [out-dir]
+#
+# Supported triples:
+#   x86_64-apple-darwin          aarch64-apple-darwin
+#   x86_64-unknown-linux-gnu     aarch64-unknown-linux-gnu
+#   wasm32-unknown-emscripten
+#
+# Environment overrides:
+#   CC                C++ compiler (defaults per triple)
+#   AR                archiver (defaults per triple)
+#   RAYLIB_DIR        path to raylib sources (default: raylib)
+#   IMGUI_DIR         path to imgui sources (default: imgui)
+#   DEAR_BINDINGS_DIR path to dear_bindings (https://github.com/dearimgui/dear_bindings);
+#                     when set, an imgui C API (dcimgui.cpp) is generated and linked in
+#   GENERATED_DIR     directory for the generated C API (default: generated)
+#
+# Output: <out-dir>/librlImGui-<target-triple>.a
+
+set -euo pipefail
+
+TRIPLE="${1:?usage: build-lib.sh <target-triple> [out-dir]}"
+OUT_DIR="${2:-$(pwd)}"
+RAYLIB_DIR="${RAYLIB_DIR:-raylib}"
+IMGUI_DIR="${IMGUI_DIR:-imgui}"
+DEAR_BINDINGS_DIR="${DEAR_BINDINGS_DIR:-}"
+GENERATED_DIR="${GENERATED_DIR:-generated}"
+
+for d in "$RAYLIB_DIR" "$IMGUI_DIR"; do
+	[[ -d "$d" ]] || {
+		echo "error: missing dependency directory '$d' (clone raylib and imgui first)" >&2
+		exit 1
+	}
+done
+
+CAPI_ENABLED=0
+if [[ -n "$DEAR_BINDINGS_DIR" ]]; then
+	[[ -d "$DEAR_BINDINGS_DIR" ]] || {
+		echo "error: DEAR_BINDINGS_DIR '$DEAR_BINDINGS_DIR' not found" >&2
+		exit 1
+	}
+	if [[ ! -f "$GENERATED_DIR/dcimgui.cpp" ]]; then
+		echo "generating imgui C API with dear_bindings..."
+		python3 -c "import ply" 2>/dev/null || {
+			echo "error: generating the C API requires Python with 'ply' (pip install ply)" >&2
+			exit 1
+		}
+		mkdir -p "$GENERATED_DIR"
+		python3 "$DEAR_BINDINGS_DIR/dear_bindings.py" \
+			--nogeneratedefaultargfunctions -o "$GENERATED_DIR/dcimgui" "$IMGUI_DIR/imgui.h"
+	fi
+fi
+if [[ -f "$GENERATED_DIR/dcimgui.cpp" ]]; then
+	CAPI_ENABLED=1
+fi
+
+case "$TRIPLE" in
+x86_64-apple-darwin)
+	CC="${CC:-clang++}"
+	AR="${AR:-ar}"
+	ARCH=(-arch x86_64)
+	PLATFORM_DEFS=(-DPLATFORM_DESKTOP -DGRAPHICS_API_OPENGL_33)
+	;;
+aarch64-apple-darwin)
+	CC="${CC:-clang++}"
+	AR="${AR:-ar}"
+	ARCH=(-arch arm64)
+	PLATFORM_DEFS=(-DPLATFORM_DESKTOP -DGRAPHICS_API_OPENGL_33)
+	;;
+x86_64-unknown-linux-gnu)
+	CC="${CC:-g++}"
+	AR="${AR:-ar}"
+	ARCH=(-m64 -fPIC)
+	PLATFORM_DEFS=(-DPLATFORM_DESKTOP -DGRAPHICS_API_OPENGL_33)
+	;;
+aarch64-unknown-linux-gnu)
+	CC="${CC:-g++}"
+	AR="${AR:-ar}"
+	ARCH=(-fPIC)
+	PLATFORM_DEFS=(-DPLATFORM_DESKTOP -DGRAPHICS_API_OPENGL_33)
+	;;
+wasm32-unknown-emscripten)
+	CC="${CC:-em++}"
+	AR="${AR:-emar}"
+	ARCH=()
+	PLATFORM_DEFS=(-DPLATFORM_WEB -DGRAPHICS_API_OPENGL_ES2)
+	;;
+*)
+	echo "error: unsupported target triple '$TRIPLE'" >&2
+	exit 1
+	;;
+esac
+
+SOURCES=(
+	rlImGui.cpp
+	"$IMGUI_DIR/imgui.cpp"
+	"$IMGUI_DIR/imgui_demo.cpp"
+	"$IMGUI_DIR/imgui_draw.cpp"
+	"$IMGUI_DIR/imgui_tables.cpp"
+	"$IMGUI_DIR/imgui_widgets.cpp"
+)
+if [[ "$CAPI_ENABLED" -eq 1 ]]; then
+	SOURCES+=("$GENERATED_DIR/dcimgui.cpp")
+fi
+
+COMMON=(
+	-O2 -std=c++17 -DNDEBUG
+	-DIMGUI_DISABLE_OBSOLETE_FUNCTIONS -DIMGUI_DISABLE_OBSOLETE_KEYIO
+	"${PLATFORM_DEFS[@]}"
+)
+INCLUDES=(
+	-I. -I"$IMGUI_DIR"
+	-I"$RAYLIB_DIR/src" -I"$RAYLIB_DIR/src/external"
+	-I"$RAYLIB_DIR/src/external/glfw/include"
+)
+if [[ "$CAPI_ENABLED" -eq 1 ]]; then
+	INCLUDES+=(-I"$GENERATED_DIR")
+fi
+
+BUILD_DIR="$OUT_DIR/.build-$TRIPLE"
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+OBJECTS=()
+for src in "${SOURCES[@]}"; do
+	obj="$BUILD_DIR/$(basename "$src" .cpp).o"
+	"$CC" -c "${COMMON[@]}" "${ARCH[@]}" "${INCLUDES[@]}" "$src" -o "$obj"
+	OBJECTS+=("$obj")
+done
+
+OUT="$OUT_DIR/librlImGui-$TRIPLE.a"
+"$AR" rcs "$OUT" "${OBJECTS[@]}"
+rm -rf "$BUILD_DIR"
+
+echo "built $OUT"


### PR DESCRIPTION
added a script to build rlimgui static libs for windows, linux, mac and wasm for all available target triples in github CI.
This would be useful for people (like me) who just want to download and ship these libs as third party bins in their apps.

Fully understand if this is not the direction you want to take, i can maintain a fork in that case.
If you do want to merge this let me know and i will cleanup the scripts a bit first.